### PR TITLE
Fix links to wasm-bindgen

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A USB library which works seamlessly across most native and WASM targets.
 > [!IMPORTANT]
 > When compiling this crate on a WASM target, you must use either the rustflags
 > `RUSTFLAGS=--cfg=web_sys_unstable_apis` or by passing the argument in a
-> `.cargo/config.toml` file. Read more here: https://rustwasm.github.io/wasm-bindgen/web-sys/unstable-apis.html
+> `.cargo/config.toml` file. Read more here: https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html
 
 ## Dependencies
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! * When compiling this crate on a WASM target, you **must** use either
 //!   `RUSTFLAGS=--cfg=web_sys_unstable_apis` or by passing the argument in a
 //!   `.cargo/config.toml` file. Read more here:
-//!   <https://rustwasm.github.io/wasm-bindgen/web-sys/unstable-apis.html>
+//!   <https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html>
 //!
 //! ## Example:
 //! ```no_run


### PR DESCRIPTION
Fixes links regarding wasm-bingen's unstable apis to the correct url. 
Context:
As of 7/2025, the rustwasm github org was archived. Wasm-bingen and its companion projects (web-sys, js-sys etc.)  were moved. More about this [here](https://blog.rust-lang.org/inside-rust/2025/07/21/sunsetting-the-rustwasm-github-org/).